### PR TITLE
move S3 endpoint URL to attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,4 @@
+default['s3fs-fuse'][:s3_url] = 'https://s3.amazonaws.com'
 default['s3fs-fuse'][:s3_key] = ''
 default['s3fs-fuse'][:s3_secret] = ''
 default['s3fs-fuse'][:version] = '1.61'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -28,7 +28,7 @@ unless(node['s3fs-fuse'][:bluepill])
       fstype 'fuse'
       dump 0
       pass 0
-      options "allow_other,url=https://s3.amazonaws.com,passwd_file=/etc/passwd-s3fs,use_cache=#{dir_info[:tmp_store] || '/tmp/s3_cache'},retries=20#{",noupload" if dir_info[:no_upload]},#{dir_info[:read_only] ? 'ro' : 'rw'}"
+      options "allow_other,url=#{node['s3fs-fuse'][:s3_url]},passwd_file=/etc/passwd-s3fs,use_cache=#{dir_info[:tmp_store] || '/tmp/s3_cache'},retries=20#{",noupload" if dir_info[:no_upload]},#{dir_info[:read_only] ? 'ro' : 'rw'}"
       action [:mount, :enable]
       not_if "mountpoint -q #{dir_info[:path]}"
     end


### PR DESCRIPTION
Moved S3 endpoint URL to attributes for supporting S3-compatible API such as Cloudian.
