### PR TITLE
Updated and fixed a few issues.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .kitchen/
 .kitchen.local.yml
+/nbproject/

--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,6 @@
 source "https://supermarket.getchef.com"
 
+metadata
+
 cookbook 'rc_mon'
 cookbook 'bluepill'

--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,4 @@
+source "https://supermarket.getchef.com"
+
+cookbook 'rc_mon'
+cookbook 'bluepill'

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Usage
 
 ```ruby
 override_attributes(
-  's3fs-fuse' => {
+  's3fs_fuse' => {
     :s3_key => 'key',
     :s3_secret => 'secret',
     :mounts => [

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -9,3 +9,5 @@ default[:s3fs_fuse][:rc_mon] = false
 default[:s3fs_fuse][:maxmemory] = 100
 default[:s3fs_fuse][:fuse_mirror] = 'voxel'
 default[:s3fs_fuse][:packages] = []
+default[:s3fs_fuse][:force_install] = false
+default[:s3fs_fuse][:version_file] = '/etc/s3fs_fuse_version'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,7 +1,7 @@
 default[:s3fs_fuse][:s3_url] = 'https://s3.amazonaws.com'
 default[:s3fs_fuse][:s3_key] = ''
 default[:s3fs_fuse][:s3_secret] = ''
-default[:s3fs_fuse][:version] = '1.61'
+default[:s3fs_fuse][:version] = '1.78'
 default[:s3fs_fuse][:no_upload] = false
 default[:s3fs_fuse][:mounts] = []
 default[:s3fs_fuse][:bluepill] = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,5 +6,5 @@ description      "Installs/Configures s3fs-fuse"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.1.4"
 
-suggests 'bluepill'
+depends 'bluepill'
 depends 'rc_mon'

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -54,8 +54,8 @@ end
 bash "compile_and_install_s3fs" do
   cwd '/tmp'
   code <<-EOH
-    tar -xzf s3fs-#{s3fs_version}.tar.gz
-    cd s3fs-#{s3fs_version}
+    tar -xzf s3fs-#{s3fs_version}.tar.gz -C ./s3fs-#{s3fs_version}
+    cd ./s3fs-#{s3fs_version}/*
     #{'export PKG_CONFIG_PATH=/usr/lib/pkgconfig:/usr/lib64/pkgconfig' if node.platform_family == 'rhel'}
     ./configure --prefix=/usr/local
     make && make install

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -44,7 +44,7 @@ prereqs.each do |prereq_name|
 end
 
 s3fs_version = node[:s3fs_fuse][:version]
-source_url = "http://github.com/s3fs-fuse/s3fs-fuse/archive/v#{s3fs_version}.tar.gz"
+source_url = "https://github.com/s3fs-fuse/s3fs-fuse/archive/v#{s3fs_version}.tar.gz"
 
 remote_file "/tmp/s3fs-#{s3fs_version}.tar.gz" do
   source source_url

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -58,6 +58,7 @@ bash "compile_and_install_s3fs" do
     tar -xzf s3fs-#{s3fs_version}.tar.gz -C ./s3fs-#{s3fs_version}
     cd ./s3fs-#{s3fs_version}/*
     #{'export PKG_CONFIG_PATH=/usr/lib/pkgconfig:/usr/lib64/pkgconfig' if node.platform_family == 'rhel'}
+    ./autogen.sh
     ./configure --prefix=/usr/local
     make && make install
   EOH

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -21,7 +21,7 @@ case node.platform_family
     )
     # As of Ubuntu 14.04 "fuse-utils" has been merged into package "fuse"
     # so try to install both (auto-installed by fuse-utils in older)
-    %x(sudo apt-cache show fuse-utils)
+    %x(apt-cache show fuse-utils >> /dev/null)
     if( $? == 0 ) then
       prereqs.push( 'fuse-utils' )
     else

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -85,11 +85,6 @@ bash "load_fuse" do
   }
 end
 
-ruby_block 's3fs_fuse_post_install' do
-  block do
-    if s3fs_fuse_installed()
-      `echo "#{node[:s3fs_fuse][:version]}" > #{node[:s3fs_fuse][:version_file]}`
-    end
-  end
-  action :run
+template node[:s3fs_fuse][:version_file] do
+  mode 0655
 end

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -11,31 +11,30 @@ template '/etc/passwd-s3fs' do
   mode 0600
 end
 
-prereqs = case node.platform_family
-when 'debian'
-  %w(
-    build-essential
-    libfuse-dev
-    fuse-utils
-    libcurl4-openssl-dev
-    libxml2-dev
-    mime-support
-  )
-when 'rhel'
-  %w(
-    gcc
-    libstdc++-devel
-    gcc-c++
-    curl-devel
-    libxml2-devel
-    openssl-devel
-    mailcap
-    fuse
-    fuse-devel
-    fuse-libs
-  )
-else
-  raise "Unsupported platform family provided: #{node.platform_family}"
+prereqs = []
+
+case node.platform_family
+  when 'debian'
+    prereqs.push(
+      'build-essential', 'libfuse-dev', 'libcurl4-openssl-dev', 'libxml2-dev',
+      'mime-support'
+    )
+    # As of Ubuntu 14.04 "fuse-utils" has been merged into package "fuse"
+    # so try to install both (auto-installed by fuse-utils in older)
+    %x(sudo apt-cache show fuse-utils)
+    if( $? == 0 ) then
+      prereqs.push( 'fuse-utils' )
+    else
+      prereqs.push( 'fuse' )
+    end
+  when 'rhel'
+    prereqs.push(
+      'gcc', 'libstdc++-devel', 'gcc-c++', 'curl-devel', 'libxml2-devel',
+      'libxml2-devel', 'openssl-devel', 'mailcap', 'fuse', 'fuse-devel',
+      'fuse-libs'
+    )
+  else
+    raise "Unsupported platform family provided: #{node.platform_family}"
 end
 
 prereqs = node[:s3fs_fuse][:packages] unless node[:s3fs_fuse][:packages].empty?

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -84,3 +84,12 @@ bash "load_fuse" do
     system('cat /boot/config-`uname -r` | grep -P "^CONFIG_FUSE_FS=y$" > /dev/null')
   }
 end
+
+ruby_block 's3fs_fuse_post_install' do
+  block do
+    if s3fs_fuse_installed()
+      `echo "#{node[:s3fs_fuse][:version]}" > #{node[:s3fs_fuse][:version_file]}`
+    end
+  end
+  action :run
+end

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -45,7 +45,7 @@ prereqs.each do |prereq_name|
 end
 
 s3fs_version = node[:s3fs_fuse][:version]
-source_url = "http://s3fs.googlecode.com/files/s3fs-#{s3fs_version}.tar.gz"
+source_url = "http://github.com/s3fs-fuse/s3fs-fuse/archive/v#{s3fs_version}.tar.gz"
 
 remote_file "/tmp/s3fs-#{s3fs_version}.tar.gz" do
   source source_url

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -21,7 +21,7 @@ case node.platform_family
     )
     # As of Ubuntu 14.04 "fuse-utils" has been merged into package "fuse"
     # so try to install both (auto-installed by fuse-utils in older)
-    %x(apt-cache show fuse-utils >> /dev/null)
+    %x(apt-cache show fuse-utils 2>&1 1>/dev/null)
     if( $? == 0 ) then
       prereqs.push( 'fuse-utils' )
     else

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -54,6 +54,7 @@ end
 bash "compile_and_install_s3fs" do
   cwd '/tmp'
   code <<-EOH
+    mkdir ./s3fs-#{s3fs_version}
     tar -xzf s3fs-#{s3fs_version}.tar.gz -C ./s3fs-#{s3fs_version}
     cd ./s3fs-#{s3fs_version}/*
     #{'export PKG_CONFIG_PATH=/usr/lib/pkgconfig:/usr/lib64/pkgconfig' if node.platform_family == 'rhel'}

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -69,7 +69,7 @@ bash "compile_and_install_s3fs" do
       false
     end
   end
-  if(node[:s3fs_fuse][:bluepill] && File.exists?(File.join(node[:bluepill][:conf_dir], 's3fs.pill')))
+  if(node[:s3fs_fuse][:bluepill] && File.exists?(File.join(node[:s3fs_fuse][:bluepill][:conf_dir], 's3fs.pill')))
     notifies :stop, 'bluepill_service[s3fs]'
     notifies :start, 'bluepill_service[s3fs]'
   end

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -69,7 +69,7 @@ bash "compile_and_install_s3fs" do
       false
     end
   end
-  if(node[:s3fs_fuse][:bluepill] && File.exists?(File.join(node[:s3fs_fuse][:bluepill][:conf_dir], 's3fs.pill')))
+  if(node[:s3fs_fuse][:bluepill].kind_of?(Array) && File.exists?(File.join(node[:s3fs_fuse][:bluepill][:conf_dir], 's3fs.pill')))
     notifies :stop, 'bluepill_service[s3fs]'
     notifies :start, 'bluepill_service[s3fs]'
   end

--- a/templates/default/s3fs_fuse_version
+++ b/templates/default/s3fs_fuse_version
@@ -1,0 +1,1 @@
+<%= node[:s3fs_fuse][:version] %>


### PR DESCRIPTION
Previous build was not working in AWS OpsWorks on Ubuntu 14.04. I updated the URI to the git repository ( fixes #9 ), updated the version to the latest 1.78, updated required packages ( fuse-utils have been merged into fuse as of Ubuntu 14.04 - new code checks for existence of fuse-utils package and falls back to the fuse package ), and updated install command to open proper directory and executes commands according to the installation notes ( https://github.com/s3fs-fuse/s3fs-fuse/wiki/Installation-Notes ). Tested and confirmed in AWS OpsWorks on Ubuntu 14.04.
